### PR TITLE
Add a Gibbs sampler for the Horseshoe prior and a Polya-gamma normal scale-mixture expansion

### DIFF
--- a/aemcmc/dists.py
+++ b/aemcmc/dists.py
@@ -1,0 +1,112 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+from aesara.sparse.basic import _is_sparse_variable, dense_from_sparse
+from aesara.tensor.random.op import RandomVariable
+from polyagamma import random_polyagamma
+
+
+class PolyaGammaRV(RandomVariable):
+    name = "polyagamma"
+    ndim_supp = 0
+    ndims_params = [0, 0]
+    dtype = "floatX"
+    _print_name = ("PG", "\\operatorname{PG}")
+
+    def __call__(self, h=1.0, z=0.0, size=None, **kwargs):
+        return super().__call__(h, z, size=size, **kwargs)
+
+    @classmethod
+    def rng_fn(cls, rng, h, z, size=None):
+        bg = rng._bit_generator if isinstance(rng, np.random.RandomState) else rng
+        return random_polyagamma(h, z, size=size, random_state=bg).astype(
+            aesara.config.floatX
+        )
+
+
+polyagamma = PolyaGammaRV()
+
+
+def multivariate_normal_rue2005(rng, b, Q):
+    """
+    Sample from a multivariate normal distribution of the form N(Qinv * b, Qinv).
+
+    We use the algorithm described in [1]. This algorithm is suitable for when
+    the number of regression coefficients is significantly less than the number
+    of data points.
+
+    References
+    ----------
+    ..[1] Rue, H. and Held, L. (2005), Gaussian Markov Random Fields, Boca
+          Raton: Chapman & Hall/CRC.
+    """
+    if _is_sparse_variable(Q):
+        Q = dense_from_sparse(Q)
+    L = at.linalg.cholesky(Q)
+    w = at.slinalg.solve_triangular(L, b, lower=True)
+    u = at.slinalg.solve_triangular(L.T, w, lower=False)
+    z = rng.standard_normal(size=L.shape[0])
+    v = at.slinalg.solve_triangular(L.T, z, lower=False)
+    return u + v
+
+
+# A and omega are assumed to be diagonal
+def multivariate_normal_cong2017(rng, A, omega, phi, t):
+    """
+    Sample from a multivariate normal distribution with a structured mean
+    and covariance matrix, as described in Example 4 [page 17] of [1]. This
+    algorithm is suitable for high-dimensional regression problems and the
+    runtime scales linearly with the number of regression coefficients.
+
+    This implementation assumes that A and omega are  diagonal matrices and
+    the parameters ``A`` and ``omega`` are expected to be an arrays containing
+    diagonal entries of the matrices.
+
+    References
+    ----------
+    ..[1] Cong, Yulai; Chen, Bo; Zhou, Mingyuan. Fast Simulation of Hyperplane-
+          Truncated Multivariate Normal Distributions. Bayesian Anal. 12 (2017),
+          no. 4, 1017--1037. doi:10.1214/17-BA1052.
+    """
+    A_inv = 1 / A
+    a_rows = A.shape[0]
+    z = rng.standard_normal(size=a_rows + omega.shape[0])
+    y1 = at.sqrt(A_inv) * z[:a_rows]
+    y2 = (1 / at.sqrt(omega)) * z[a_rows:]
+    Ainv_phi = A_inv[:, None] * phi.T
+    B = phi @ Ainv_phi
+    indices = at.arange(B.shape[0])
+    B = at.subtensor.set_subtensor(
+        B[indices, indices],
+        at.diag(B) + 1.0 / omega,
+    )
+    alpha = at.linalg.solve(B, t - phi @ y1 - y2, assume_a="pos")
+    return y1 + Ainv_phi @ alpha
+
+
+def multivariate_normal_bhattacharya2016(rng, D, phi, alpha):
+    """
+    Sample from a multivariable normal distribution of the form:
+        N(Sigma * phi.T * alpha, Sigma),
+        where Sigma = inv(phi.T * phi + inv(D)) and D is positive definite.
+
+    This implementation assumes that D is a symmetric matrix and the parameter
+    ``D`` is expected to be an array containing diagonal entries of the D matrix.
+
+    References
+    ----------
+    ..[1] Bhattacharya, A., Chakraborty, A., and Mallick, B. K. (2016).
+          “Fast sampling with Gaussian scale mixture priors in high-dimensional
+          regression.” Biometrika, 103(4): 985.033
+    """
+    D_phi = D[:, None] * phi.T
+    B = phi @ D_phi
+    indices = at.arange(B.shape[0])
+    B = at.subtensor.set_subtensor(
+        B[indices, indices],
+        at.diag(B) + 1.0,
+    )
+    u = rng.normal(0, at.sqrt(D))
+    v = phi @ u + rng.standard_normal(size=phi.shape[0])
+    w = at.linalg.solve(B, alpha - v, assume_a="pos")
+    return u + D_phi @ w

--- a/aemcmc/negative_binomial_horseshoe_gibbs.py
+++ b/aemcmc/negative_binomial_horseshoe_gibbs.py
@@ -1,0 +1,190 @@
+import aesara
+import aesara.tensor as at
+from aesara.ifelse import ifelse
+from aesara.tensor.var import TensorVariable
+
+from aemcmc.dists import (
+    multivariate_normal_cong2017,
+    multivariate_normal_rue2005,
+    polyagamma,
+)
+
+
+def update_beta_low_dimension(rng, omega, lambda2tau2_inv, X, z):
+    Q = X.T @ (omega[:, None] * X)
+    indices = at.arange(Q.shape[1])
+    Q = at.subtensor.set_subtensor(
+        Q[indices, indices],
+        at.diag(Q) + lambda2tau2_inv,
+    )
+    return multivariate_normal_rue2005(rng, X.T @ (omega * z), Q)
+
+
+def update_beta_high_dimension(rng, omega, lambda2tau2_inv, X, z):
+    return multivariate_normal_cong2017(rng, lambda2tau2_inv, omega, X, z)
+
+
+def update_beta(rng, omega, lambda2tau2_inv, X, z):
+    return ifelse(
+        X.shape[1] > X.shape[0],
+        update_beta_high_dimension(rng, omega, lambda2tau2_inv, X, z),
+        update_beta_low_dimension(rng, omega, lambda2tau2_inv, X, z),
+    )
+
+
+# NOTE: invGamma(1, a) === 1 / Exp(a), where a is the scale/mean of the exponential
+def horseshoe_step(srng, beta, sigma2, lambda2_inv, tau2_inv):
+    upsilon_inv = srng.exponential(1 + lambda2_inv)
+    zeta_inv = srng.exponential(1 + tau2_inv)
+
+    beta2 = beta * beta
+    lambda2_inv_new = srng.exponential(upsilon_inv + 0.5 * beta2 * tau2_inv / sigma2)
+    tau2_inv_new = srng.gamma(
+        0.5 * (beta.shape[0] + 1),
+        zeta_inv + 0.5 * (beta2 * lambda2_inv_new).sum() / sigma2,
+    )
+    return lambda2_inv_new, tau2_inv_new, upsilon_inv, zeta_inv
+
+
+def horseshoe_nbinom_gibbs(
+    srng: at.random.RandomStream,
+    X: TensorVariable,
+    y: TensorVariable,
+    h: TensorVariable,
+    beta_init: TensorVariable,
+    local_shrinkage_init: TensorVariable,
+    global_shrinkage_init: TensorVariable,
+    n_samples: TensorVariable,
+):
+    r"""
+    Compose a symbolic graph that describes the gibbs sampler of the negative
+    binomial regression with a HorseShoe prior on the regression coefficients.
+
+    The implemenation follows the sampler desribed in [1].
+
+    Parameters
+    ----------
+    srng: symbolic random number generator
+        The random number generating object to be used during sampling.
+    X: TensorVariable
+        The covariate matrix.
+    y: TensorVariable
+        The observed count data.
+    h: TensorVariable
+        The "number of successes" parameter of the negative binomial disribution
+        used to model the data.
+    beta_init: TensorVariable
+        A tensor describing the starting values of the posterior samples of
+        the regression coefficients.
+    local_shrinkage_init: TensorVariable
+        A tensor describing the starting values of the local shrinkage
+        parameter of the horseshoe prior.
+    global_shrinkage_init: TensorVariable
+        A tensor describing the starting values of the global shrinkage
+        parameter of the horseshoe prior.
+    n_samples: TensorVariable
+        A tensor describing the number of posterior samples to generate.
+
+    Returns
+    -------
+    (outputs, updates): tuple
+        A symbolic sescription of the sampling result to be used when
+        compiling a function to be used for sampling.
+
+    Notes
+    -----
+    [2] mention that the intercept term should not be subject to any
+    regularization and thus needs to be explicitely modelled. As recommented by
+    the authors, we use a uniform prior on the intercept of the regression
+    coefficients and its posterior conditional distribution is shown in
+    equation (14) of [2]. The ``z`` expression in section 2.2 of [1] seems to
+    omit division by the Polya-Gamma auxilliary variables whereas [2] and [3]
+    explicitely include it. We found that including the division results in
+    accurate posterior samples for the regression coefficients. It is also
+    worth noting that the :math:`\sigma^2` parameter is not sampled directly
+    in the negative binomial regression problem and thus set to 1 [2].
+
+    References
+    ----------
+    ..[1] Makalic, Enes & Schmidt, Daniel. (2015). A Simple Sampler for the
+          Horseshoe Estimator. 10.1109/LSP.2015.2503725.
+    ..[2] Makalic, Enes & Schmidt, Daniel. (2016). High-Dimensional Bayesian
+          Regularised Regression with the BayesReg Package.
+    ..[3] Neelon, Brian. (2019). Bayesian Zero-Inflated Negative Binomial
+          Regression Based on Pólya-Gamma Mixtures. Bayesian Anal.
+          2019 September ; 14(3): 829–855. doi:10.1214/18-ba1132.
+    """
+    beta = at.as_tensor_variable(beta_init, "beta", dtype=aesara.config.floatX)
+    if beta.ndim != 1:
+        raise ValueError(
+            "`beta_init` must be a vector whose length is equal to the "
+            "number of columns in the covariate matrix"
+        )
+
+    lambda2 = at.as_tensor_variable(
+        local_shrinkage_init, name="lambda2", dtype=aesara.config.floatX
+    )
+    if lambda2.ndim != 1:
+        raise ValueError(
+            "The local shrinkage initial value must be a vector whose size "
+            "is equal to the number of columns in the covariate matrix"
+        )
+
+    tau2 = at.as_tensor_variable(
+        global_shrinkage_init, name="tau2", dtype=aesara.config.floatX
+    )
+    if tau2.ndim != 0:
+        raise ValueError("The global shrinkage initial value must be a scalar")
+
+    n_samples = at.as_tensor_variable(n_samples, name="n_samples", dtype=int)
+    if n_samples.ndim != 0:
+        raise ValueError("The number of samples should be an integer scalar")
+
+    # sigma2 must be set to 1 during sampling for this sampler and the
+    # logistic regression version. It is only required if the data is
+    # modelled using linear regression.
+    sigma2 = at.constant(1, "sigma2")
+
+    # set the initial value of the intercept term to a random uniform value.
+    beta0 = at.empty_like(tau2)
+    beta0.name = "intercept"
+    beta0 = srng.uniform(-10, 10)
+
+    def step_fn(
+        beta0: TensorVariable,
+        beta: TensorVariable,
+        lambda2_inv: TensorVariable,
+        tau2_inv: TensorVariable,
+        sigma2: TensorVariable,
+        X: TensorVariable,
+        y: TensorVariable,
+        h: TensorVariable,
+    ):
+        """
+        Complete one full update of the gibbs sampler and return the new state
+        of the posterior conditional parameters.
+        """
+        xb = X @ beta
+        w = srng.gen(polyagamma, y + h, beta0 + xb)
+
+        z = 0.5 * (y - h) / w
+        beta0_var = 1 / w.sum()
+        beta0_mean = beta0_var * (w @ (z - xb))
+        beta0_new = srng.normal(beta0_mean, at.sqrt(beta0_var))
+
+        beta_new = update_beta(srng, w, lambda2_inv * tau2_inv, X, z - beta0_new)
+
+        lambda2_inv_new, tau2_inv_new, _, _ = horseshoe_step(
+            srng, beta_new, sigma2, lambda2_inv, tau2_inv
+        )
+
+        return beta0_new, beta_new, lambda2_inv_new, tau2_inv_new
+
+    outputs, updates = aesara.scan(
+        step_fn,
+        outputs_info=[beta0, beta, 1 / lambda2, 1 / tau2],
+        non_sequences=[sigma2, X, y, h],
+        n_steps=n_samples,
+        strict=True,
+    )
+    return outputs, updates

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ black==20.8b1; platform.python_implementation!='PyPy'
 diff-cover
 autoflake
 pre-commit
+polyagamma>=1.3.2

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -1,0 +1,77 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+import pytest
+from aesara.sparse.basic import as_sparse
+from scipy.sparse import csc_matrix
+
+from aemcmc.dists import (
+    multivariate_normal_bhattacharya2016,
+    multivariate_normal_cong2017,
+    multivariate_normal_rue2005,
+    polyagamma,
+)
+
+
+def test_polyagamma():
+    assert polyagamma(size=(5, 4)).eval().shape == (5, 4)
+
+    with pytest.raises(ValueError, match="values of `h` must be positive"):
+        polyagamma([1, -0]).eval()
+
+    default_dtype = aesara.config.floatX
+    aesara.config.floatX = "float32"
+    assert polyagamma().eval().dtype == "float32"
+    aesara.config.floatX = default_dtype
+
+    rng1 = at.random.RandomStream(12345)
+    res1 = rng1.gen(polyagamma)
+    rng2 = at.random.RandomStream(12345)
+    res2 = rng2.gen(polyagamma)
+    assert res1.eval() == res2.eval()
+
+
+def test_multivariate_normal_rue2005():
+    nrng = np.random.default_rng(54321)
+    b = np.array([0.5, -0.2, 0.75, 1.0, -2.22])
+    Q = csc_matrix(np.diag(nrng.random(5)))
+
+    srng = at.random.RandomStream(12345)
+    got = multivariate_normal_rue2005(srng, at.as_tensor(b), as_sparse(Q))
+    expected = np.array(
+        [-0.87260997, 0.24812936, -0.14312798, 30.57354048, -6.83054447]
+    )
+    np.testing.assert_allclose(got.eval(), expected)
+
+
+def test_multivariate_normal_bhattacharya2016():
+    nrng = np.random.default_rng(54321)
+    X = nrng.standard_normal(size=10 * 5)
+    X.resize((10, 5))
+    XX = X.T @ X
+    D, phi = np.linalg.eigh(XX)
+    alpha = nrng.random(phi.shape[1])
+
+    srng = at.random.RandomStream(12345)
+    got = multivariate_normal_bhattacharya2016(
+        srng, at.as_tensor(D), at.as_tensor(phi), at.as_tensor(alpha)
+    )
+    expected = np.array([0.13220936, 0.20621965, -2.98777855, -2.35904856, -0.19972386])
+    np.testing.assert_allclose(got.eval(), expected)
+
+
+def test_multivariate_normal_cong2017():
+    nrng = np.random.default_rng(54321)
+    X = nrng.standard_normal(size=10 * 5)
+    X.resize((10, 5))
+    XX = X.T @ X
+    omega, phi = np.linalg.eigh(XX)
+    A = nrng.random(phi.shape[1])
+    t = nrng.random(phi.shape[1])
+
+    srng = at.random.RandomStream(12345)
+    got = multivariate_normal_cong2017(
+        srng, at.as_tensor(A), at.as_tensor(omega), at.as_tensor(phi), at.as_tensor(t)
+    )
+    expected = np.array([0.79532198, 0.54771371, 0.42505174, -0.33428737, -0.74749463])
+    np.testing.assert_allclose(got.eval(), expected)

--- a/tests/test_horseshoe_nbinom_gibbs.py
+++ b/tests/test_horseshoe_nbinom_gibbs.py
@@ -1,0 +1,82 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+import pytest
+from aesara.tensor.random.utils import RandomStream
+from scipy.linalg import toeplitz
+
+from aemcmc.negative_binomial_horseshoe_gibbs import horseshoe_nbinom_gibbs
+
+
+def test_horseshoe_nbinom_gibbs():
+    """
+    This test example is modified from section 3.2 of Makalic & Schmidt (2016)
+    """
+    h = 2
+    p = 10
+    N = 50
+    srng = RandomStream(seed=12345)
+    true_beta0 = srng.uniform(-1, 1)
+    true_beta = np.array([5, 3, 3, 1, 1] + [0] * (p - 5))
+    S = toeplitz(0.5 ** np.arange(p))
+    X = srng.multivariate_normal(np.zeros(p), cov=S, size=N)
+    y = srng.nbinom(h, at.sigmoid(-(X.dot(true_beta) + true_beta0)))
+
+    beta_init, lambda2_init, tau2_init, n_samples = (
+        at.vector("beta_init"),
+        at.vector("lambda2_init"),
+        at.scalar("tau2_init"),
+        at.iscalar("n_samples"),
+    )
+    outputs, updates = horseshoe_nbinom_gibbs(
+        srng, X, y, h, beta_init, lambda2_init, tau2_init, n_samples
+    )
+    sample_fn = aesara.function(
+        [beta_init, lambda2_init, tau2_init, n_samples], outputs, updates=updates
+    )
+
+    rng = np.random.default_rng(54321)
+    posterior_samples = 2000
+    beta0, beta, lambda2_inv, tau2_inv = sample_fn(
+        rng.normal(0, 5, size=p), np.ones(p), 1, posterior_samples
+    )
+
+    assert beta0.shape == (posterior_samples,)
+    assert beta.shape == (posterior_samples, p)
+    assert lambda2_inv.shape == (posterior_samples, p)
+    assert tau2_inv.shape == (posterior_samples,)
+
+    # test distribution domains
+    assert np.all(tau2_inv > 0)
+    assert np.all(lambda2_inv > 0)
+
+    # test if the sampler fails with wrong input
+    with pytest.raises(ValueError, match="`beta_init` must be a vector "):
+        wrong_beta_init = at.tensor3("wrong_beta_init")
+        horseshoe_nbinom_gibbs(
+            srng, X, y, h, wrong_beta_init, lambda2_init, tau2_init, n_samples
+        )
+
+    with pytest.raises(
+        ValueError, match="The local shrinkage initial value must be a vector"
+    ):
+        wrong_lambda2_init = at.scalar("wrong_lambda2_init")
+        horseshoe_nbinom_gibbs(
+            srng, X, y, h, beta_init, wrong_lambda2_init, tau2_init, n_samples
+        )
+
+    with pytest.raises(
+        ValueError, match="The global shrinkage initial value must be a scalar"
+    ):
+        wrong_tau2_init = at.matrix("wrong_tau2_init")
+        horseshoe_nbinom_gibbs(
+            srng, X, y, h, beta_init, lambda2_init, wrong_tau2_init, n_samples
+        )
+
+    with pytest.raises(
+        ValueError, match="The number of samples should be an integer scalar"
+    ):
+        wrong_n_samples = at.vector("wrong_n_samples")
+        horseshoe_nbinom_gibbs(
+            srng, X, y, h, beta_init, lambda2_init, tau2_init, wrong_n_samples
+        )


### PR DESCRIPTION
This PR adds functions for creating sampler steps for a normal regression under a Horseshoe prior as described in  "A Simple Sampler for the Horseshoe Estimator" (Makalic, Enes & Schmidt, Daniel, 2015).  
It also implements the Polya-gamma normal scale mixture expansion described in "Data Augmentation for Non-Gaussian Regression Models Using Variance-Mean Mixtures" (Polson, Nicholas G., and James G. Scott, 2013) and the multivariate normal sampler in "Fast Simulation of Hyperplane-Truncated Multivariate Normal Distributions" (Cong, Yulai, Bo Chen, and Mingyuan Zhou, 2017).