### PR TITLE
Bump black version to 22.3.0 in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: debug-statements
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         language_version: python3


### PR DESCRIPTION
The pre-commit style checks currently fail because of a probleme with
the `click` dependency:  https://github.com/psf/black/issues/2964. The
recommended solution is to upgrade `black` to v22.3.0, which we do in
this commit..