### PR TITLE
Remove Python 3.6 and add 3.10 to CI test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.7", "3.10"]
         fast-compile: [0]
         float32: [0]
         part:


### PR DESCRIPTION
Python 3.6's support stopped [3 months ago](https://endoflife.date/python) so I don't think we should support it. Python 3.10 was released 6 months ago and we should make sure `aemcmc` is compatible. This closes #20.