### PR TITLE
Make `aemcmc` compatible with sparse data input

### DIFF
--- a/aemcmc/dists.py
+++ b/aemcmc/dists.py
@@ -74,14 +74,14 @@ def multivariate_normal_cong2017(rng, A, omega, phi, t):
     y1 = at.sqrt(A_inv) * z[:a_rows]
     y2 = (1 / at.sqrt(omega)) * z[a_rows:]
     Ainv_phi = A_inv[:, None] * phi.T
-    B = phi @ Ainv_phi
+    B = at.dot(phi, Ainv_phi)
     indices = at.arange(B.shape[0])
     B = at.subtensor.set_subtensor(
         B[indices, indices],
         at.diag(B) + 1.0 / omega,
     )
-    alpha = at.linalg.solve(B, t - phi @ y1 - y2, assume_a="pos")
-    return y1 + Ainv_phi @ alpha
+    alpha = at.linalg.solve(B, t - at.dot(phi, y1) - y2, assume_a="pos")
+    return y1 + at.dot(Ainv_phi, alpha)
 
 
 def multivariate_normal_bhattacharya2016(rng, D, phi, alpha):
@@ -100,13 +100,13 @@ def multivariate_normal_bhattacharya2016(rng, D, phi, alpha):
           regression.” Biometrika, 103(4): 985.033
     """
     D_phi = D[:, None] * phi.T
-    B = phi @ D_phi
+    B = at.dot(phi, D_phi)
     indices = at.arange(B.shape[0])
     B = at.subtensor.set_subtensor(
         B[indices, indices],
         at.diag(B) + 1.0,
     )
     u = rng.normal(0, at.sqrt(D))
-    v = phi @ u + rng.standard_normal(size=phi.shape[0])
+    v = at.dot(phi, u) + rng.standard_normal(size=phi.shape[0])
     w = at.linalg.solve(B, alpha - v, assume_a="pos")
-    return u + D_phi @ w
+    return u + at.dot(D_phi, w)

--- a/aemcmc/gibbs.py
+++ b/aemcmc/gibbs.py
@@ -14,13 +14,13 @@ from aemcmc.dists import (
 
 
 def update_beta_low_dimension(rng, omega, lambda2tau2_inv, X, z):
-    Q = X.T @ (omega[:, None] * X)
+    Q = at.dot(X.T, (omega[:, None] * X))
     indices = at.arange(Q.shape[1])
     Q = at.subtensor.set_subtensor(
         Q[indices, indices],
         at.diag(Q) + lambda2tau2_inv,
     )
-    return multivariate_normal_rue2005(rng, X.T @ (omega * z), Q)
+    return multivariate_normal_rue2005(rng, at.dot(X.T, (omega * z)), Q)
 
 
 def update_beta_high_dimension(rng, omega, lambda2tau2_inv, X, z):
@@ -247,12 +247,12 @@ def horseshoe_nbinom(
             The "number of successes" parameter of the negative binomial disribution
             used to model the data.
         """
-        xb = X @ beta
+        xb = at.dot(X, beta)
         w = srng.gen(polyagamma, y + h, beta0 + xb)
 
         z = 0.5 * (y - h) / w
         beta0_var = 1 / w.sum()
-        beta0_mean = beta0_var * (w @ (z - xb))
+        beta0_mean = beta0_var * at.dot(w, (z - xb))
         beta0_new = srng.normal(beta0_mean, at.sqrt(beta0_var))
 
         beta_new = update_beta(srng, w, lambda2_inv * tau2_inv, X, z - beta0_new)
@@ -401,12 +401,12 @@ def horseshoe_logistic(
             The observed binary data
         """
 
-        xb = X @ beta
+        xb = at.dot(X, beta)
         w = srng.gen(polyagamma, 1, beta0 + xb)
 
         z = (y - 0.5) / w
         beta0_var = 1 / w.sum()
-        beta0_mean = beta0_var * (w @ (z - xb))
+        beta0_mean = beta0_var * at.dot(w, (z - xb))
         beta0_new = srng.normal(beta0_mean, at.sqrt(beta0_var))
 
         beta_new = update_beta(srng, w, lambda2_inv * tau2_inv, X, z - beta0_new)


### PR DESCRIPTION
We noticed in #19 that `aemcmc` samplers did not work with sparse tensors as an input. This seems to be related to the implementation of the `@` operator in Aesara (https://github.com/aesara-devs/aesara/issues/881) which, unlike `aesara.tensor.dot`, seems to only work with dense tensors. 

In this PR we replace every instance of `@` with `aesara.tensor.dot`, and add a test to make sure that sparse matrices can be used as inputs to `horseshoe_nbinom` and `horseshoe_logitstic`. Closes #19.
