### PR TITLE
Add a Gibbs sampler for the negative-binomial dispersion parameter

### DIFF
--- a/aemcmc/gibbs.py
+++ b/aemcmc/gibbs.py
@@ -145,9 +145,8 @@ def horseshoe_step(
     .. math::
 
         \begin{align*}
-            \beta_j &\sim \operatorname{Normal}(0, \lambda_j^2\;\tau^2\;\sigma^2)\\
-            \sigma^2 &\sim \sigma^{-2} \mathrm{d} \sigma\\
-            \lambda_j &\sim \operatorname{HalfCauchy}(0, 1)\\
+            \beta_j &\sim \operatorname{N}\left(0, \lambda_j^2 \tau^2 \sigma^2\right) \\
+            \lambda_j &\sim \operatorname{HalfCauchy}(0, 1) \\
             \tau &\sim \operatorname{HalfCauchy}(0, 1)
         \end{align*}
 
@@ -156,7 +155,7 @@ def horseshoe_step(
 
     1. The half-Cauchy distribution can be intepreted as a mixture of inverse-gamma
     distributions;
-    2. If :math:` Y \sim InverseGamma(1, a)`, :math:`Y \sim 1 / \operatorname{Exp}(a)`.
+    2. If :math:` Y \sim \operatorname{InvGamma}(1, a)`, :math:`Y \sim 1 / \operatorname{Exp}(a)`.
 
     Parameters
     ----------
@@ -173,7 +172,7 @@ def horseshoe_step(
 
     References
     ----------
-    ..[1] Makalic, Enes & Schmidt, Daniel. (2016). High-Dimensional Bayesian
+    .. [1] Makalic, Enes & Schmidt, Daniel. (2016). High-Dimensional Bayesian
           Regularised Regression with the BayesReg Package.
 
     """
@@ -255,18 +254,17 @@ def nbinom_horseshoe_gibbs(
 ) -> Tuple[Union[TensorVariable, List[TensorVariable]], Dict]:
     r"""Build a Gibbs sampler for the negative binomial regression with a horseshoe prior.
 
-    The implementation follows the sampler described in [1]. It is designed to
+    The implementation follows the sampler described in [1]_. It is designed to
     sample efficiently from the following negative binomial regression model:
 
     .. math::
 
         \begin{align*}
-            y_i &\sim \operatorname{NegativeBinomial}\left(\pi_i, h\right)\\
-            h &\sim \pi_h(h) \mathrm{d}h\\
-            \pi_i &= \frac{\exp(\psi_i)}{1 + \exp(\psi_i)}\\
-            \psi_i &= x^T \beta\\
-            \beta_j &\sim \operatorname{Normal}(0, \lambda_j^2\;\tau^2)\\
-            \lambda_j &\sim \operatorname{HalfCauchy}(0, 1)\\
+            Y_i &\sim \operatorname{NB}\left(p_i, h\right) \\
+            p_i &= \frac{\exp(\psi_i)}{1 + \exp(\psi_i)} \\
+            \psi_i &= x_i^\top \beta \\
+            \beta_j &\sim \operatorname{N}(0, \lambda_j^2 \tau^2) \\
+            \lambda_j &\sim \operatorname{HalfCauchy}(0, 1) \\
             \tau &\sim \operatorname{HalfCauchy}(0, 1)
         \end{align*}
 
@@ -290,20 +288,20 @@ def nbinom_horseshoe_gibbs(
 
     Notes
     -----
-    The ``z`` expression in section 2.2 of [1] seems to
-    omit division by the Polya-Gamma auxilliary variables whereas [2] and [3]
+    The :math:`z` expression in Section 2.2 of [1]_ seems to
+    omit division by the Polya-Gamma auxilliary variables whereas [2]_ and [3]_
     explicitely include it. We found that including the division results in
     accurate posterior samples for the regression coefficients. It is also
     worth noting that the :math:`\sigma^2` parameter is not sampled directly
-    in the negative binomial regression problem and thus set to 1 [2].
+    in the negative binomial regression problem and thus set to 1 [2]_.
 
     References
     ----------
-    ..[1] Makalic, Enes & Schmidt, Daniel. (2015). A Simple Sampler for the
+    .. [1] Makalic, Enes & Schmidt, Daniel. (2015). A Simple Sampler for the
           Horseshoe Estimator. 10.1109/LSP.2015.2503725.
-    ..[2] Makalic, Enes & Schmidt, Daniel. (2016). High-Dimensional Bayesian
+    .. [2] Makalic, Enes & Schmidt, Daniel. (2016). High-Dimensional Bayesian
           Regularised Regression with the BayesReg Package.
-    ..[3] Neelon, Brian. (2019). Bayesian Zero-Inflated Negative Binomial
+    .. [3] Neelon, Brian. (2019). Bayesian Zero-Inflated Negative Binomial
           Regression Based on Pólya-Gamma Mixtures. Bayesian Anal.
           2019 September ; 14(3): 829–855. doi:10.1214/18-ba1132.
 
@@ -317,7 +315,7 @@ def nbinom_horseshoe_gibbs(
         X: TensorVariable,
         h: TensorVariable,
     ) -> Tuple[TensorVariable, TensorVariable, TensorVariable]:
-        """Complete one full update of the gibbs sampler and return the new state
+        """Complete one full update of the Gibbs sampler and return the new state
         of the posterior conditional parameters.
 
         Parameters
@@ -414,32 +412,32 @@ def bernoulli_horseshoe_match(
 def bernoulli_horseshoe_gibbs(
     srng: RandomStream, Y_rv: TensorVariable, y: TensorVariable, num_samples: int
 ) -> Tuple[Union[TensorVariable, List[TensorVariable]], Dict]:
-    r"""Build a Gibbs sampler for bernoulli (logistic) regression with a horseshoe prior.
+    r"""Build a Gibbs sampler for Bernoulli (logistic) regression with a horseshoe prior.
 
-    The implementation follows the sampler described in [1]. It is designed to
+    The implementation follows the sampler described in [1]_. It is designed to
     sample efficiently from the following binary logistic regression model:
 
     .. math::
 
         \begin{align*}
-            y_i &\sim \operatorname{Bernoulli}\left(\pi_i\right)\\
-            \pi &= \frac{1}{1 + \exp\left(-(\beta_0 + x_i^T\,\beta)\right)}\\
-            \beta_j &\sim \operatorname{Normal}(0, \lambda_j^2\;\tau^2)\\
-            \lambda_j &\sim \operatorname{HalfCauchy}(0, 1)\\
+            Y_i &\sim \operatorname{Bern}\left(p_i\right) \\
+            p_i &= \frac{1}{1 + \exp\left(-(\beta_0 + x_i^\top \beta)\right)} \\
+            \beta_j &\sim \operatorname{N}(0, \lambda_j^2 \tau^2) \\
+            \lambda_j &\sim \operatorname{HalfCauchy}(0, 1) \\
             \tau &\sim \operatorname{HalfCauchy}(0, 1)
         \end{align*}
 
     Parameters
     ----------
-    srng: symbolic random number generator
+    srng
         The random number generating object to be used during sampling.
     Y_rv
         Model graph.
-    y: TensorVariable
+    y
         The observed binary data.
-    X: TensorVariable
+    X
         The covariate matrix.
-    n_samples: TensorVariable
+    n_samples
         A tensor describing the number of posterior samples to generate.
 
     Returns
@@ -451,9 +449,9 @@ def bernoulli_horseshoe_gibbs(
 
     References
     ----------
-    ..[1] Makalic, Enes & Schmidt, Daniel. (2015). A Simple Sampler for the
+    .. [1] Makalic, Enes & Schmidt, Daniel. (2015). A Simple Sampler for the
           Horseshoe Estimator. 10.1109/LSP.2015.2503725.
-    ..[2] Makalic, Enes & Schmidt, Daniel. (2016). High-Dimensional Bayesian
+    .. [2] Makalic, Enes & Schmidt, Daniel. (2016). High-Dimensional Bayesian
           Regularised Regression with the BayesReg Package.
 
     """
@@ -465,7 +463,7 @@ def bernoulli_horseshoe_gibbs(
         y: TensorVariable,
         X: TensorVariable,
     ) -> Tuple[TensorVariable, TensorVariable, TensorVariable]:
-        """Complete one full update of the gibbs sampler and return the new
+        """Complete one full update of the Gibbs sampler and return the new
         state of the posterior conditional parameters.
 
         Parameters
@@ -476,9 +474,9 @@ def bernoulli_horseshoe_gibbs(
             Square of the local shrinkage parameter of the horseshoe prior.
         tau
             Square of the global shrinkage parameters of the horseshoe prior.
-        y: TensorVariable
+        y
             The observed binary data
-        X: TensorVariable
+        X
             The covariate matrix.
 
         """

--- a/tests/test_gibbs.py
+++ b/tests/test_gibbs.py
@@ -2,6 +2,8 @@ import aesara
 import aesara.tensor as at
 import numpy as np
 import pytest
+import scipy.special
+from aesara.graph.basic import equal_computations
 from aesara.tensor.random.utils import RandomStream
 from scipy.linalg import toeplitz
 
@@ -9,11 +11,16 @@ from aemcmc.gibbs import (
     bernoulli_horseshoe_gibbs,
     bernoulli_horseshoe_match,
     bernoulli_horseshoe_model,
+    gamma_match,
+    h_step,
     horseshoe_match,
     horseshoe_model,
     nbinom_horseshoe_gibbs,
+    nbinom_horseshoe_gibbs_with_dispersion,
     nbinom_horseshoe_match,
     nbinom_horseshoe_model,
+    nbinom_horseshoe_with_dispersion_match,
+    sample_CRT,
 )
 
 
@@ -147,6 +154,122 @@ def test_horseshoe_nbinom(srng):
     assert np.all(lmbda > 0)
 
 
+@pytest.mark.parametrize(
+    "h_val, y_val",
+    [
+        (1.0, 0),
+        (1.0, 1),
+        (1.0, 20),
+        (10.0, 20),
+    ],
+)
+def test_sample_CRT_mean(srng, h_val, y_val):
+    y = at.lvector("y")
+    h = at.scalar("h")
+
+    crt_res, updates = sample_CRT(srng, y, h)
+
+    crt_fn = aesara.function([y, h], crt_res, updates=updates)
+
+    y_vals = np.repeat(y_val, 5000).astype(np.int64)
+
+    crt_vals = crt_fn(y_vals, h_val)
+
+    crt_mean_val = crt_vals.mean()
+    crt_exp_val = h_val * (
+        scipy.special.digamma(h_val + y_val) - scipy.special.digamma(h_val)
+    )
+
+    assert np.allclose(crt_mean_val, crt_exp_val, rtol=1e-1)
+
+
+def test_h_step(srng):
+
+    true_h = 10
+    M = 10
+    N = 50
+
+    true_beta = np.array([2, 0.02, 0.2, 0.1, 1] + [0.1] * (M - 5))
+    S = toeplitz(0.5 ** np.arange(M))
+    X = srng.multivariate_normal(np.zeros(M), cov=S, size=N)
+    p_at = at.sigmoid(-(X.dot(true_beta)))
+    p, y = aesara.function([], [p_at, srng.nbinom(true_h, p_at)])()
+
+    a_val = 1.0
+    b_val = 2e-1
+    a = at.as_tensor(a_val)
+    b = at.as_tensor(b_val)
+
+    h_samples, h_updates = aesara.scan(
+        lambda: h_step(srng, at.as_tensor(true_h), p, a, b, y), n_steps=1000
+    )
+
+    h_mean_fn = aesara.function([], h_samples.mean(), updates=h_updates)
+
+    h_mean_val = h_mean_fn()
+
+    # Make sure that the posterior `h` values aren't right around the prior
+    # mean
+    assert not np.allclose(h_mean_val, a_val / b_val, rtol=2e-1)
+
+    # Make sure the posterior values are near the "true" value
+    assert np.allclose(h_mean_val, true_h, rtol=2e-1)
+
+
+def test_horseshoe_nbinom_w_dispersion(srng):
+    """
+    This test example is modified from section 3.2 of Makalic & Schmidt (2016)
+    """
+    true_h = 10
+    M = 10
+    N = 50
+
+    # generate synthetic data
+    true_beta = np.array([2, 0.02, 0.2, 0.1, 1] + [0.1] * (M - 5))
+    S = toeplitz(0.5 ** np.arange(M))
+    X_at = srng.multivariate_normal(np.zeros(M), cov=S, size=N)
+    X, y = aesara.function(
+        [], [X_at, srng.nbinom(true_h, at.sigmoid(-(X_at.dot(true_beta))))]
+    )()
+    X = at.as_tensor(X)
+    y = at.as_tensor(y)
+
+    # build the model
+    tau_rv = srng.halfcauchy(0, 1, name="tau")
+    lambda_rv = srng.halfcauchy(0, 1, size=M, name="lambda")
+    beta_rv = srng.normal(0, tau_rv * lambda_rv, size=M, name="beta")
+
+    eta_tt = X @ beta_rv
+    p_tt = at.sigmoid(-eta_tt)
+    p_tt.name = "p"
+
+    h_rv = srng.gamma(100, 1, name="h")
+
+    Y_rv = srng.nbinom(h_rv, p_tt, name="Y")
+
+    # sample from the posterior distributions
+    num_samples = at.lscalar("num_samples")
+    outputs, updates = nbinom_horseshoe_gibbs_with_dispersion(
+        srng, Y_rv, y, num_samples
+    )
+
+    sample_fn = aesara.function((num_samples,), outputs, updates=updates)
+
+    sample_num = 2000
+    beta, lmbda, tau, h = sample_fn(sample_num)
+
+    assert beta.shape == (sample_num, M)
+    assert lmbda.shape == (sample_num, M)
+    assert tau.shape == (sample_num, 1)
+    assert h.shape == (sample_num,)
+
+    assert np.all(tau > 0)
+    assert np.all(lmbda > 0)
+    assert np.all(h > 0)
+
+    assert np.allclose(h.mean(), true_h, rtol=1e-1)
+
+
 def test_match_bernoulli_horseshoe(srng):
     bernoulli_horseshoe_match(bernoulli_horseshoe_model(srng))
 
@@ -205,3 +328,38 @@ def test_bernoulli_horseshoe(srng):
     # test distribution domains
     assert np.all(tau > 0)
     assert np.all(lmbda > 0)
+
+
+def test_gamma_match(srng):
+    beta_rv = srng.normal(0, 1)
+    with pytest.raises(ValueError):
+        gamma_match(beta_rv)
+
+    a = at.scalar("a")
+    b = at.scalar("b")
+    beta_rv = srng.gamma(a, b)
+    a_m, b_m = gamma_match(beta_rv)
+
+    assert a_m is a
+
+    b_exp = at.as_tensor(1.0, dtype="floatX") / b
+    assert equal_computations([b_m], [b_exp])
+
+
+def test_nbinom_horseshoe_with_dispersion_match(srng):
+    a = at.scalar("a")
+    b = at.scalar("b")
+    X = at.matrix("X")
+
+    beta_rv = horseshoe_model(srng)
+    eta = X @ beta_rv
+    p = at.sigmoid(-eta)
+    h = srng.gamma(a, b)
+    Y_rv = srng.nbinom(h, p)
+
+    X_m, beta_m, lmbda_m, tau_m, h_m, a_m, b_m = nbinom_horseshoe_with_dispersion_match(
+        Y_rv
+    )
+
+    assert a_m is a
+    assert X_m is X


### PR DESCRIPTION
This PR will be adding Gibbs steps that would allow sampling for dispersion terms of Negative Binomial. 

This PR will follow the compound poisson method mentioned [here](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4180062/)

So far we roughy added the Gibbs steps for  
1. r -dispersion terms in N(r, p)
2. h - Inverse of scale parameter for gamma distribution of r
3. L_i - The number terms of L/N of a Poisson distributed variable in Compound Poisson distribution

The most tricky part so far comes form the sampling of L_i as it is a discrete sampling from a given probability vector where the probability vector comes from a pre-calculated matrix with some additional computation. 

Next step is to add `match` functions for the NB graph with dispersion terms. 
