### PR TITLE
Add relation for recentering and rescaling

### DIFF
--- a/aemcmc/transforms.py
+++ b/aemcmc/transforms.py
@@ -1,0 +1,72 @@
+import aesara.tensor as at
+from etuples import etuple, etuplize
+from kanren import eq, lall
+from kanren.facts import Relation, fact
+from unification import var
+
+location_scale_family = Relation("location-scale-family")
+fact(location_scale_family, at.random.cauchy)
+fact(location_scale_family, at.random.gumbel)
+fact(location_scale_family, at.random.laplace)
+fact(location_scale_family, at.random.logistic)
+fact(location_scale_family, at.random.normal)
+
+
+def location_scale_transform(in_expr, out_expr):
+    r"""Produce a goal that represents the action of lifting and sinking
+    the scale and location parameters of distributions in the location-scale
+    family.
+
+    For instance
+
+    .. math::
+
+        \begin{equation*}
+            \frac{
+                X \sim \operatorname{N}\left(\mu_x, \sigma_x^2\right), \quad
+                Y \sim \operatorname{N}\left(\mu_y, \sigma_y^2\right), \quad
+                X + Y = Z
+            }{
+                Z \sim \operatorname{N}\left(\mu_x + \mu_y, \sigma_x^2 + \sigma_y^2\right)
+            }
+        \end{equation*}
+
+    Parameters
+    ----------
+    in_expr
+        An expression that represents a random variable whose distribution belongs
+        to the location-scale family.
+    out_expr
+        An expression for the non-centered representation of this random variable.
+
+    """
+
+    # Centered representation
+    rng_lv, size_lv, type_idx_lv = var(), var(), var()
+    mu_lv, sd_lv = var(), var()
+    distribution_lv = var()
+    centered_et = etuple(distribution_lv, rng_lv, size_lv, type_idx_lv, mu_lv, sd_lv)
+
+    # Non-centered representation
+    noncentered_et = etuple(
+        etuplize(at.add),
+        mu_lv,
+        etuple(
+            etuplize(at.mul),
+            sd_lv,
+            etuple(
+                distribution_lv,
+                0,
+                1,
+                rng=rng_lv,
+                size=size_lv,
+                dtype=type_idx_lv,
+            ),
+        ),
+    )
+
+    return lall(
+        eq(in_expr, centered_et),
+        eq(out_expr, noncentered_et),
+        location_scale_family(distribution_lv),
+    )

--- a/tests/test_conjugates.py
+++ b/tests/test_conjugates.py
@@ -28,7 +28,6 @@ def test_beta_binomial_conjugate_contract():
     q_lv = var()
     (posterior_expr,) = run(1, q_lv, beta_binomial_conjugateo((Y_rv, y_vv), q_lv))
     posterior = eval_if_etuple(posterior_expr)
-    aesara.dprint(posterior)
 
     assert isinstance(posterior.owner.op, type(at.random.beta))
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,0 +1,47 @@
+import aesara.tensor as at
+import pytest
+from aesara.graph.fg import FunctionGraph
+from aesara.graph.kanren import KanrenRelationSub
+
+from aemcmc.transforms import location_scale_transform
+
+
+def test_normal_scale_loc_transform_lift():
+
+    srng = at.random.RandomStream(0)
+    mu_rv = srng.halfnormal(1.0)
+    sigma_rv = srng.halfcauchy(1)
+    Y_rv = srng.normal(mu_rv, sigma_rv)
+
+    fgraph = FunctionGraph(outputs=[Y_rv], clone=False)
+    res = KanrenRelationSub(location_scale_transform).transform(
+        fgraph, fgraph.outputs[0].owner
+    )[0]
+
+    # Make sure that Y_rv gets replaced with an addition
+    assert res.owner.op == at.add
+    lhs = res.owner.inputs[0]
+    assert isinstance(lhs.owner.op, type(at.random.halfnormal))
+    rhs = res.owner.inputs[1]
+    assert rhs.owner.op == at.mul
+    assert isinstance(rhs.owner.inputs[0].owner.op, type(at.random.halfcauchy))
+    assert isinstance(rhs.owner.inputs[1].owner.op, type(at.random.normal))
+
+
+@pytest.mark.xfail(
+    reason="Op.__call__ does not dispatch to Op.make_node for some RandomVariable and etuple evaluation returns an error"
+)
+def test_normal_scale_loc_transform_sink():
+
+    srng = at.random.RandomStream(0)
+    mu_rv = srng.halfnormal(1.0)
+    sigma_rv = srng.halfcauchy(1)
+    std_normal_rv = srng.normal(0, 1)
+    Y_at = mu_rv + sigma_rv * std_normal_rv
+
+    fgraph = FunctionGraph(outputs=[Y_at], clone=False)
+    res = KanrenRelationSub(lambda x, y: location_scale_transform(y, x)).transform(
+        fgraph, fgraph.outputs[0].owner
+    )[0]
+
+    assert isinstance(res.owner.op, type(at.random.normal))


### PR DESCRIPTION
In this PR we add a relation that represents loc-scale transformations (the relation between the "centered" and "non-centered" parametrization). The performance of some sampling algorithms (eg HMC) can be affected by the parametrization of the model provided by the user (see [this example](https://pymc-devs.github.io/symbolic-pymc/theano-radon-example.html)). 

We would like `aemcmc` to be aware of the different parametrizations so [users don't have to](https://arxiv.org/abs/1906.03028
) worry of these implementation details.

- [x] Create a relation for the normal loc-scale transformation
- [ ] Add test with multiple, nested substitutions
- [x] Generalize to several distributions in the [location-scale family](https://en.wikipedia.org/wiki/Location%E2%80%93scale_family)

I see that [the Symbolic-PyMC implementation](https://github.com/pymc-devs/symbolic-pymc/blob/84e8d612c714f502f8d188c1766498f4ff7beecf/symbolic_pymc/relations/theano/distributions.py#L112) excludes the cases where `loc=0` and `sd=1` but I am not sure that it is necessary since the relation still holds in this case (even though pointless but algebraic simplification after transformation should take care of this).

_Note :_ We should implement the location and scale transformations separately: distributions like the exponential distributions are part of the scale but not location-scale family.

Closes #5 