### PR TITLE
Add the NUTS sampler constructor

### DIFF
--- a/aemcmc/nuts.py
+++ b/aemcmc/nuts.py
@@ -1,0 +1,146 @@
+from typing import Callable, Dict, Tuple
+
+import aesara
+from aehmc import nuts as aehmc_nuts
+from aehmc.utils import RaveledParamsMap
+from aeppl import joint_logprob
+from aeppl.transforms import RVTransform, TransformValuesOpt, _default_transformed_rv
+from aesara.tensor.random import RandomStream
+from aesara.tensor.var import TensorVariable
+
+from aemcmc.utils import ModelInfo
+
+NUTSStateType = Tuple[TensorVariable, TensorVariable, TensorVariable]
+NUTSKernelType = Callable[
+    [NUTSStateType],
+    Tuple[
+        Tuple[
+            NUTSStateType,
+            Dict[TensorVariable, TensorVariable],
+            Dict[TensorVariable, TensorVariable],
+        ],
+        Dict,
+    ],
+]
+
+
+def nuts(
+    srng: RandomStream,
+    model: ModelInfo,
+    inverse_mass_matrix: TensorVariable,
+    step_size: TensorVariable,
+) -> Tuple[NUTSStateType, NUTSKernelType]:
+    """Build a NUTS kernel and the initial state.
+
+    This function currently assumes that we will update the value of all of the
+    model's variables with the NUTS sampler.
+
+    Parameters
+    ----------
+    model
+        The Aesara model whose posterior distribution we wish to sample from
+        passed as a `ModelInfo` instance.
+    step_size
+        The step size used in the symplectic integrator.
+    inverse_mass_matrix
+        One or two-dimensional array used as the inverse mass matrix that
+        defines the euclidean metric.
+
+    """
+    unobserved_rvs = tuple(
+        rv for rv in model.rvs_to_values.keys() if rv not in model.observed_rvs
+    )
+    unobserved_rvs_to_values = {rv: model.rvs_to_values[rv] for rv in unobserved_rvs}
+    observed_vvs = tuple(model.rvs_to_values[rv] for rv in model.observed_rvs)
+
+    # Algorithms in the HMC family can more easily explore the posterior distribution
+    # when the support of each random variable's distribution is unconstrained.
+    # First we build the logprob graph in the transformed space.
+    transforms = {
+        vv: get_transform(rv) if rv in unobserved_rvs else None
+        for rv, vv in model.rvs_to_values.items()
+    }
+
+    logprob_sum = joint_logprob(
+        model.rvs_to_values, extra_rewrites=TransformValuesOpt(transforms)
+    )
+
+    # Then we transform the value variables.
+    transformed_vvs = {
+        vv: transform_forward(rv, vv, transforms[vv])
+        for rv, vv in unobserved_rvs_to_values.items()
+    }
+
+    # Algorithms in `aehmc` work with flat arrays and we need to ravel parameter
+    # values to use them as an input to the NUTS kernel.
+    rp_map = RaveledParamsMap(tuple(transformed_vvs.values()))
+    rp_map.ref_params = tuple(transformed_vvs.keys())
+
+    # We can now write the logprob function associated with the model and build
+    # the NUTS kernel.
+    def logprob_fn(q):
+        unraveled_q = rp_map.unravel_params(q)
+        unraveled_q.update({vv: vv for vv in observed_vvs})
+
+        memo = aesara.graph.basic.clone_get_equiv(
+            [], [logprob_sum], copy_inputs=False, copy_orphans=False, memo=unraveled_q
+        )
+
+        return memo[logprob_sum]
+
+    nuts_kernel = aehmc_nuts.new_kernel(srng, logprob_fn)
+
+    def step_fn(state):
+        """Take one step with the NUTS kernel.
+
+        The NUTS kernel works with a state that contains the current value of
+        the variables, but also the current value of the potential and its
+        gradient, and we need to carry this state forward. We also return the
+        unraveled parameter values in both the original and transformed space.
+
+        """
+        (new_q, new_pe, new_peg, *_), updates = nuts_kernel(
+            *state, step_size, inverse_mass_matrix
+        )
+        new_state = (new_q, new_pe, new_peg)
+        transformed_params = rp_map.unravel_params(new_q)
+        params = {
+            vv: transform_backward(rv, transformed_params[vv], transforms[vv])
+            for rv, vv in unobserved_rvs_to_values.items()
+        }
+        return (new_state, params, transformed_params), updates
+
+    # Finally we build the initial state
+    initial_q = rp_map.ravel_params(tuple(transformed_vvs.values()))
+    initial_state = aehmc_nuts.new_state(initial_q, logprob_fn)
+
+    return initial_state, step_fn
+
+
+def get_transform(rv: TensorVariable):
+    """Get the default transform associated with the random variable."""
+    transform = _default_transformed_rv(rv.owner.op, rv.owner)
+    if transform:
+        return transform.op.transform
+    else:
+        return None
+
+
+def transform_forward(rv: TensorVariable, vv: TensorVariable, transform: RVTransform):
+    """Push variables to the transformed space."""
+    if transform:
+        res = transform.forward(vv, *rv.owner.inputs)
+        if vv.name:
+            res.name = f"{vv.name}_trans"
+        return res
+    else:
+        return vv
+
+
+def transform_backward(rv: TensorVariable, vv: TensorVariable, transform: RVTransform):
+    """Pull variables back from the transformed space."""
+    if transform:
+        res = transform.backward(vv, *rv.owner.inputs)
+        return res
+    else:
+        return vv

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
         "scipy>=1.4.0",
         "aesara>=2.6.6",
         "aeppl>=0.0.31",
+        "aehmc>=0.0.5",
         "polyagamma>=1.3.2",
         "cons",
         "logical-unification",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "scipy>=1.4.0",
         "aesara>=2.6.6",
         "aeppl>=0.0.31",
-        "aehmc>=0.0.5",
+        "aehmc>=0.0.6",
         "polyagamma>=1.3.2",
         "cons",
         "logical-unification",

--- a/tests/test_nuts.py
+++ b/tests/test_nuts.py
@@ -1,0 +1,65 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+import pytest
+from aeppl import joint_logprob
+from aesara.tensor.random import RandomStream
+
+from aemcmc.nuts import nuts
+from aemcmc.utils import ModelInfo
+
+
+def test_nuts():
+    srng = RandomStream(0)
+    mu_rv = srng.normal(0, 1, name="mu")
+    sigma_rv = srng.halfnormal(0.0, 1.0, name="sigma")
+    Y_rv = srng.normal(mu_rv, sigma_rv, name="Y")
+
+    mu_vv = mu_rv.clone()
+    mu_vv.name = "mu_vv"
+    sigma_vv = sigma_rv.clone()
+    sigma_vv.name = "sigma_vv"
+    Y_at = at.scalar(name="Y_at")
+
+    rvs_to_values = {mu_rv: mu_vv, sigma_rv: sigma_vv, Y_rv: Y_at}
+    model = ModelInfo((Y_rv,), rvs_to_values, (), ())
+
+    inverse_mass_matrix = at.as_tensor([1.0, 1.0])
+    step_size = at.as_tensor(0.1)
+    state_at, step_fn = nuts(srng, model, inverse_mass_matrix, step_size)
+
+    # Make sure that the state is properly initialized
+    state_fn = aesara.function((mu_vv, sigma_vv, Y_at), state_at)
+    state = state_fn(1.0, 1.0, 1.0)
+
+    position = state[0]
+    assert position[0] == 1.0
+    assert position[1] != 1.0  # The state is in the transformed space
+    logprob = joint_logprob(rvs_to_values)
+    assert state[1] == -1 * logprob.eval({Y_at: 1.0, mu_vv: 1.0, sigma_vv: 1.0})
+
+    # Make sure that the step function updates the state
+    (new_state, params, transformed_params), updates = step_fn(state_at)
+    update_fn = aesara.function(
+        (mu_vv, sigma_vv, Y_at),
+        (
+            params[mu_vv],
+            params[sigma_vv],
+            transformed_params[mu_vv],
+            transformed_params[sigma_vv],
+        ),
+        updates=updates,
+    )
+
+    new_position = update_fn(1.0, 1.0, 1.0)
+    untransformed_position = np.array([new_position[0], new_position[1]])
+    transformed_position = np.array([new_position[2], new_position[3]])
+
+    # Did the chain advance?
+    np.testing.assert_raises(
+        AssertionError, np.testing.assert_equal, untransformed_position, [1.0, 1.0]
+    )
+
+    # Are the transformations applied correctly?
+    assert untransformed_position[0] == pytest.approx(transformed_position[0])  # mu
+    assert untransformed_position[1] != transformed_position[1]  # sigma


### PR DESCRIPTION
In this PR we add a function that uses the NUTS kernel implemented in `aehmc` to build a function that samples from the posterior distribution of a model specified in a `ModelInfo` instance. It is a first step towards the general-purpose sampler mentioned in #26.