### PR TITLE
Make `deterministic_vars` and `updates` optional in `ModelInfo`

### DIFF
--- a/aemcmc/utils.py
+++ b/aemcmc/utils.py
@@ -13,9 +13,9 @@ class ModelInfo:
     """Observed random/measurable variables."""
     rvs_to_values: Dict[TensorVariable, TensorVariable]
     """A map between random/measurable variables and their value variables."""
-    deterministic_vars: Tuple[TensorVariable, ...]
+    deterministic_vars: Tuple[TensorVariable, ...] = field(default_factory=tuple)
     """Stochastic variables that are tracked but not sampled directly/explicitly."""
-    updates: Optional[Dict[Variable, TensorVariable]]
+    updates: Optional[Dict[Variable, TensorVariable]] = field(default_factory=dict)
     """Updates to be passed to `aesara.function`."""
 
     values_to_rvs: Dict[TensorVariable, TensorVariable] = field(init=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,13 @@ def test_ModelInfo_maps():
     assert amodel.observed_values == (y_vv,)
     assert amodel.unobserved_rvs == (beta_rv,)
     assert amodel.unobserved_values == (beta_vv,)
+    assert amodel.updates == {}
+    assert set(amodel.names_to_vars.values()) == set((Y_rv, beta_rv, mu, y_vv, beta_vv))
+
+    smodel = ModelInfo(observed_rvs, rvs_to_values)
+    assert smodel.deterministic_vars == ()
+    assert smodel.updates == {}
+    assert set(smodel.names_to_vars.values()) == set((Y_rv, beta_rv, y_vv, beta_vv))
 
 
 def test_ModelInfo_errors():


### PR DESCRIPTION
We currently have to pass respectively an empty tuple and an empty dictionary to initialize `ModelInfo` when we do not wish to sample from deterministic variables and/or when the model does not produce updates. This PR makes the specification of `deterministic_vars` and `updates` optional.  

`rvs_to_values` and `observed_rvs` are now the only compulsory fields.

Closes #40 