### PR TITLE
Extend unittests for some distributions.

### DIFF
--- a/aemcmc/dists.py
+++ b/aemcmc/dists.py
@@ -82,31 +82,3 @@ def multivariate_normal_cong2017(rng, A, omega, phi, t):
     )
     alpha = at.linalg.solve(B, t - phi @ y1 - y2, assume_a="pos")
     return y1 + Ainv_phi @ alpha
-
-
-def multivariate_normal_bhattacharya2016(rng, D, phi, alpha):
-    """
-    Sample from a multivariable normal distribution of the form:
-        N(Sigma * phi.T * alpha, Sigma),
-        where Sigma = inv(phi.T * phi + inv(D)) and D is positive definite.
-
-    This implementation assumes that D is a symmetric matrix and the parameter
-    ``D`` is expected to be an array containing diagonal entries of the D matrix.
-
-    References
-    ----------
-    ..[1] Bhattacharya, A., Chakraborty, A., and Mallick, B. K. (2016).
-          “Fast sampling with Gaussian scale mixture priors in high-dimensional
-          regression.” Biometrika, 103(4): 985.033
-    """
-    D_phi = D[:, None] * phi.T
-    B = phi @ D_phi
-    indices = at.arange(B.shape[0])
-    B = at.subtensor.set_subtensor(
-        B[indices, indices],
-        at.diag(B) + 1.0,
-    )
-    u = rng.normal(0, at.sqrt(D))
-    v = phi @ u + rng.standard_normal(size=phi.shape[0])
-    w = at.linalg.solve(B, alpha - v, assume_a="pos")
-    return u + D_phi @ w

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -6,7 +6,6 @@ from aesara.sparse.basic import as_sparse
 from scipy.sparse import csc_matrix
 
 from aemcmc.dists import (
-    multivariate_normal_bhattacharya2016,
     multivariate_normal_cong2017,
     multivariate_normal_rue2005,
     polyagamma,
@@ -52,32 +51,6 @@ def test_multivariate_normal_rue2005():
     np.testing.assert_allclose(np.var(samples, axis=0), var, atol=0.1)
 
 
-def test_multivariate_normal_bhattacharya2016():
-    nrng = np.random.default_rng(54321)
-    X = nrng.standard_normal(size=(50, 100))
-    phi = np.linalg.cholesky(X @ X.T).T
-    D = nrng.random(phi.shape[1])
-    alpha = nrng.random(phi.shape[0])
-    precision = phi.T @ phi
-    precision[np.diag_indices_from(precision)] += 1.0 / D
-    cov = np.linalg.inv(precision)
-    mean = cov @ phi.T @ alpha
-
-    srng = at.random.RandomStream(12345)
-
-    def update():
-        return multivariate_normal_bhattacharya2016(
-            srng, at.as_tensor(D), at.as_tensor(phi), at.as_tensor(alpha)
-        )
-
-    samples_out, updates = aesara.scan(update, n_steps=10000)
-    sampling_fn = aesara.function((), samples_out, updates=updates)
-    samples = sampling_fn()
-
-    np.testing.assert_allclose(np.mean(samples, axis=0), mean, atol=0.05)
-    np.testing.assert_allclose(np.var(samples, axis=0, ddof=1), np.diag(cov), atol=0.05)
-
-
 def test_multivariate_normal_cong2017():
     nrng = np.random.default_rng(54321)
     X = nrng.standard_normal(size=(50, 100))
@@ -98,6 +71,41 @@ def test_multivariate_normal_cong2017():
             at.as_tensor(omega),
             at.as_tensor(phi.T),
             at.as_tensor(t),
+        )
+
+    samples_out, updates = aesara.scan(update, n_steps=10000)
+    sampling_fn = aesara.function((), samples_out, updates=updates)
+    samples = sampling_fn()
+
+    np.testing.assert_allclose(np.mean(samples, axis=0), mean, atol=0.05)
+    np.testing.assert_allclose(np.var(samples, axis=0, ddof=1), np.diag(cov), atol=0.05)
+
+
+def test_multivariate_normal_bhattacharya2016_via_cong2017():
+    """This test case is to test if the algorithm from Cong et al (2017) can
+    be used realiably to implement one described in Bhattacharya (2016) as a
+    special case when ``omega`` is the identity matrix.
+    """
+    nrng = np.random.default_rng(54321)
+    X = nrng.standard_normal(size=(50, 100))
+    phi = np.linalg.cholesky(X @ X.T).T
+    D = nrng.random(phi.shape[1])
+    alpha = nrng.random(phi.shape[0])
+    precision = phi.T @ phi
+    precision[np.diag_indices_from(precision)] += 1.0 / D
+    cov = np.linalg.inv(precision)
+    mean = cov @ phi.T @ alpha
+
+    srng = at.random.RandomStream(12345)
+
+    def update():
+        def multivariate_normal_bhattacharya2016(rng, D, phi, alpha):
+            return multivariate_normal_cong2017(
+                rng, 1 / D, at.ones(phi.shape[0]), phi, alpha
+            )
+
+        return multivariate_normal_bhattacharya2016(
+            srng, at.as_tensor(D), at.as_tensor(phi), at.as_tensor(alpha)
         )
 
     samples_out, updates = aesara.scan(update, n_steps=10000)


### PR DESCRIPTION
This commit fixes/completes/extends previously minimal unittests for
some of the available probability distribution samplers, which include:
- `multivariate_normal_cong2017`
- `multivariate_normal_bhattacharya2016`.

This is a followup of https://github.com/aesara-devs/aemcmc/pull/32 and closes #33 