### PR TITLE
Update `ShapeFeature` imports

### DIFF
--- a/aemcmc/rewriting.py
+++ b/aemcmc/rewriting.py
@@ -14,7 +14,7 @@ from aesara.graph.rewriting.db import SequenceDB
 from aesara.tensor.elemwise import DimShuffle, Elemwise
 from aesara.tensor.random.op import RandomVariable
 from aesara.tensor.random.utils import RandomStream
-from aesara.tensor.rewriting.basic import ShapeFeature
+from aesara.tensor.rewriting.shape import ShapeFeature
 from aesara.tensor.var import TensorVariable
 from cons.core import _car
 from unification.core import _unify

--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,9 @@ dependencies:
   - compilers
   - numpy>=1.18.1
   - scipy>=1.4.0
-  - aesara>=2.8.0
-  - aeppl>=0.0.35
-  - aehmc>=0.0.9
+  - aesara>=2.8.3
+  - aeppl>=0.0.38
+  - aehmc>=0.0.10
   - polyagamma>=1.3.2
   - cons
   - logical-unification

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,9 @@ setup(
     install_requires=[
         "numpy>=1.18.1",
         "scipy>=1.4.0",
-        "aesara>=2.8.0",
-        "aeppl>=0.0.35",
-        "aehmc>=0.0.9",
+        "aesara>=2.8.3",
+        "aeppl>=0.0.38",
+        "aehmc>=0.0.10",
         "polyagamma>=1.3.2",
         "cons",
         "logical-unification",


### PR DESCRIPTION
This PR updates the now deprecated `ShapeFeature` imports (i.e. Aesara >= 2.8.3).