### PR TITLE
Make `construct_sampler` available in the `aemcmc` namespace

### DIFF
--- a/aemcmc/__init__.py
+++ b/aemcmc/__init__.py
@@ -2,6 +2,12 @@ from . import _version
 
 __version__ = _version.get_versions()["version"]
 
+
+from aemcmc.basic import construct_sampler
+
+# isort: off
 # Register rewrite databases
 import aemcmc.conjugates
 import aemcmc.gibbs
+
+# isort: on


### PR DESCRIPTION
Closes #69. 
