### PR TITLE
Update `pre-commit`, `black`, `flake8`, `isort`, `mypy` versions in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,25 +7,25 @@ exclude: |
     )$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.1.0
+    rev: v4.3.0
     hooks:
       - id: debug-statements
       - id: check-merge-conflict
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
   - repo: https://github.com/pycqa/isort
-    rev: 5.6.4
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.982
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]


### PR DESCRIPTION
The pre-commit checks are currently failing on `main` due to a `mypy` dependency. I updated all the versions to match those in Aesara's `.pre-commit-config.yml`.