### PR TITLE
Update NUTS to work with AePPL's new `joint_logprob` interface

### DIFF
--- a/aemcmc/basic.py
+++ b/aemcmc/basic.py
@@ -5,7 +5,7 @@ from aesara.graph.fg import FunctionGraph
 from aesara.tensor.random.utils import RandomStream
 from aesara.tensor.var import TensorVariable
 
-from aemcmc.nuts import construct_nuts_sampler
+import aemcmc.nuts as nuts
 from aemcmc.rewriting import (
     SamplerTracker,
     construct_ir_fgraph,
@@ -117,7 +117,7 @@ def construct_sampler(
             for rv, vv in posterior_sample_steps.items()
             if rv not in to_sample_rvs
         }
-        (nuts_sample_steps, updates, nuts_parameters) = construct_nuts_sampler(
+        (nuts_sample_steps, updates, nuts_parameters) = nuts.construct_sampler(
             srng, to_sample_rvs, realized_values
         )
 

--- a/aemcmc/nuts.py
+++ b/aemcmc/nuts.py
@@ -29,7 +29,7 @@ NUTSKernelType = Callable[
 ]
 
 
-def construct_nuts_sampler(
+def construct_sampler(
     srng: RandomStream,
     to_sample_rvs: Dict[RandomVariable, TensorVariable],
     realized_rvs_to_values: Dict[RandomVariable, TensorVariable],

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - numpy>=1.18.1
   - scipy>=1.4.0
   - aesara>=2.8.3
-  - aeppl>=0.0.38
+  - aeppl>=0.0.40
   - aehmc>=0.0.10
   - polyagamma>=1.3.2
   - cons

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "numpy>=1.18.1",
         "scipy>=1.4.0",
         "aesara>=2.8.3",
-        "aeppl>=0.0.38",
+        "aeppl>=0.0.40",
         "aehmc>=0.0.10",
         "polyagamma>=1.3.2",
         "cons",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -115,6 +115,7 @@ def test_nuts_with_closed_form():
     )
 
     p_posterior_step = sample_steps[l_rv]
+    assert y_vv in graph_inputs([p_posterior_step])
     assert len(parameters) == 2
     assert len(initial_values) == 2
     assert isinstance(p_posterior_step.owner.op, GammaRV)

--- a/tests/test_nuts.py
+++ b/tests/test_nuts.py
@@ -1,7 +1,7 @@
 import aesara
 from aesara.tensor.random import RandomStream
 
-from aemcmc.nuts import construct_nuts_sampler
+import aemcmc.nuts as nuts
 
 
 def test_nuts():
@@ -17,7 +17,7 @@ def test_nuts():
     to_sample_rvs = {mu_rv: mu_vv, sigma_rv: sigma_vv}
     observed = {Y_rv: y_vv}
 
-    state_at, updates, parameters = construct_nuts_sampler(
+    state_at, updates, parameters = nuts.construct_sampler(
         srng, to_sample_rvs, observed
     )
 

--- a/tests/test_nuts.py
+++ b/tests/test_nuts.py
@@ -11,16 +11,14 @@ def test_nuts():
     Y_rv = srng.normal(mu_rv, sigma_rv, name="Y")
 
     mu_vv = mu_rv.clone()
-    mu_vv.name = "mu_vv"
     sigma_vv = sigma_rv.clone()
-    sigma_vv.name = "sigma_vv"
     y_vv = Y_rv.clone()
 
-    to_sample_rvs = [mu_rv, sigma_rv]
-    rvs_to_values = {mu_rv: mu_vv, sigma_rv: sigma_vv, Y_rv: y_vv}
+    to_sample_rvs = {mu_rv: mu_vv, sigma_rv: sigma_vv}
+    observed = {Y_rv: y_vv}
 
-    state_at, step_fn, parameters = construct_nuts_sampler(
-        srng, to_sample_rvs, rvs_to_values
+    state_at, updates, parameters = construct_nuts_sampler(
+        srng, to_sample_rvs, observed
     )
 
     # Make sure that the state is properly initialized
@@ -34,6 +32,7 @@ def test_nuts():
             parameters["inverse_mass_matrix"],
         ),
         sample_steps,
+        updates=updates,
     )
     new_state = state_fn(1.0, 1.0, 1.0, 0.01, [1.0, 1.0])
 


### PR DESCRIPTION
AePPL's `joint_logprob` now create the initial values for the sampled RV *in the transformed space*:

```python
logprob, initial_values = joint_logprob(
    to_sample_rvs,
    realized=realized_rvs_to_values,
    transforms=...
)
```

The change to the NUTS constructor itself was very minimal, if anything it simplified it a little (changes are mostly refactoring + better documentation).

We can now build NUTS sampling steps using:

```python
from aemcmc.nuts import construct_nuts_sampler
import aesara.tensor as at


srng = at.random.RandomStream(0)
mu_rv = srng.normal(0, 1, name="mu")
sigma_rv = srng.halfnormal(0.0, 1.0, name="sigma")
Y_rv = srng.normal(mu_rv, sigma_rv, name="Y")

mu_vv = mu_rv.clone()
sigma_vv = sigma_rv.clone()
y_vv = Y_rv.clone()

to_sample_rvs = {mu_rv: mu_vv, sigma_rv: sigma_vv}
realized_rvs = {Y_rv: y_vv}

sampling_steps, updates, parameters = construct_nuts_sampler(
    srng, to_sample_rvs, realized_rvs
)
```

I considered the following interface:

```python
from aemcmc.nuts import construct_nuts_sampler
import aesara.tensor as at


srng = at.random.RandomStream(0)
mu_rv = srng.normal(0, 1, name="mu")
sigma_rv = srng.halfnormal(0.0, 1.0, name="sigma")
Y_rv = srng.normal(mu_rv, sigma_rv, name="Y")

y_vv = Y_rv.clone()

to_sample_rvs = [mu_rv, sigma_rv]
realized_rvs = {Y_rv: y_vv}

sampling_steps, (mu_vv, sigma_vv), updates, parameters = construct_nuts_sampler(
    srng, to_sample_rvs, realized_rvs
)
```

But it does complicate the code in `construct_sampler` for little to no gain. The creation of initial values is probably better handled by a model object, like `ModelInfo` anyway.

The tests pass locally with the last commit in AePPL.

Closes #77.