### PR TITLE
Fix handling of constant inputs to `SubsumingElemwise`

### DIFF
--- a/aemcmc/basic.py
+++ b/aemcmc/basic.py
@@ -127,6 +127,6 @@ def construct_sampler(
         if rv not in obs_rvs_to_values
     }
 
-    return Sampler(sampling_steps, updates, parameters), {
+    return Sampler(sampling_steps, posterior_updates, parameters), {
         new_to_old_rvs[rv]: init_var for rv, init_var in rvs_to_init_vals.items()
     }


### PR DESCRIPTION
This fixes the error seen in #90.  

The underlying issue is that `SubsumingElemwise` extends `OpFromGraph` and the latter does not accept constant inputs (e.g. an `OpFromGraph` representing `1 / x` should only take `x` as an input, and not also `1`).  This PR removes constant inputs when the `OpFromGraph` is constructed and also strips them from calls to `SubsumingElemwise.make_node`.  The assumption is that the inputs provided in both cases (i.e. when the `Op` is constructed and when the constructed `Op` is used to create a node) refer to the same constants, which they absolutely should in this scenario.

- [x] Extend the new test so that it more directly confirms that the result is correct