### PR TITLE
Add a function to generate prior samples

### DIFF
--- a/aemcmc/__init__.py
+++ b/aemcmc/__init__.py
@@ -4,6 +4,7 @@ __version__ = _version.get_versions()["version"]
 
 
 from aemcmc.basic import construct_sampler
+from aemcmc.sample import sample_prior
 
 # isort: off
 # Register rewrite databases

--- a/aemcmc/sample.py
+++ b/aemcmc/sample.py
@@ -1,0 +1,31 @@
+import aesara
+import aesara.tensor as at
+import aesara.tensor.random as ar
+
+from aemcmc.utils import get_rv_updates
+
+
+def sample_prior(
+    srng: ar.RandomStream, num_samples: at.TensorVariable, *rvs: at.TensorVariable
+) -> at.TensorVariable:
+    """Sample from a model's prior distributions.
+
+    Parameters
+    ----------
+    srng:
+        `RandomStream` instance with which the model was defined.
+    num_samples:
+        The number of prior samples to generate.
+    rvs:
+        The random variables whose prior distribution we want to sample.
+
+    """
+
+    rv_updates = get_rv_updates(srng, *rvs)
+
+    def step_fn():
+        return rvs, rv_updates
+
+    samples, updates = aesara.scan(step_fn, n_steps=num_samples)
+
+    return samples, updates

--- a/tests/test_sample.py
+++ b/tests/test_sample.py
@@ -1,0 +1,50 @@
+import aesara
+import aesara.tensor as at
+import numpy as np
+from aesara.compile.sharedvalue import SharedVariable
+
+from aemcmc.sample import sample_prior
+
+
+def test_sample_prior():
+    srng = at.random.RandomStream(123)
+
+    mu_rv = srng.normal(0, 1, name="mu")
+    Y_rv = srng.normal(mu_rv, 1.0, name="Y")
+    Z_rv = srng.gamma(0.5, 0.5, name="Z")
+
+    samples, updates = sample_prior(srng, 10, Y_rv)
+    fn = aesara.function([], samples, updates=updates)
+
+    # Make sure that `Z_rv` doesn't sneak into our prior sampling.
+    rng_objects = set(
+        var.get_value(borrow=True)
+        for var in fn.maker.fgraph.variables
+        if isinstance(var, SharedVariable)
+    )
+
+    assert mu_rv.owner.inputs[0].get_value(borrow=True) in rng_objects
+    assert Y_rv.owner.inputs[0].get_value(borrow=True) in rng_objects
+    assert Z_rv.owner.inputs[0].get_value(borrow=True) not in rng_objects
+
+    samples_vals = fn()
+    assert np.shape(np.unique(samples_vals)) == (10,)
+
+    # Try it again, but without a default update
+    Y_rv.owner.inputs[0].default_update = None
+
+    samples, updates = sample_prior(srng, 10, Y_rv)
+    fn = aesara.function([], samples, updates=updates)
+
+    rng_objects = set(
+        var.get_value(borrow=True)
+        for var in fn.maker.fgraph.variables
+        if isinstance(var, SharedVariable)
+    )
+
+    assert mu_rv.owner.inputs[0].get_value(borrow=True) in rng_objects
+    assert Y_rv.owner.inputs[0].get_value(borrow=True) in rng_objects
+    assert Z_rv.owner.inputs[0].get_value(borrow=True) not in rng_objects
+
+    samples_vals = fn()
+    assert np.shape(np.unique(samples_vals)) == (10,)


### PR DESCRIPTION
Here we add a utility function to generate prior samples for any variable present in a model. The function should return samples in a format that is convenient for the users. The format is still TBD, although the standard in the Python PPL world seems to be XArray (for compatibility with ArviZ).

```python
import aesara
import aesara.tensor as at

from aemcmc.sample import sample_prior


srng = at.random.RandomStream(0)
mu_rv = srng.normal(0, 1)
Y_rv = srng.normal(mu_rv, 1.0)

num_samples = at.scalar()
samples, updates = sample_prior(srng, num_samples, Y_rv, mu_rv)
sample_fn = aesara.function([num_samples], samples, updates=updates)
sample_fn(10)
```

Note: it is not necessary to pass the updates to `function` in this case (but we need to make sure to return them as outputs to Scan's inner function), can we just not return them at all to simplify the interface further?

Related to #101